### PR TITLE
Change from project to thesis on frontpages

### DIFF
--- a/KTHFrontpage.sty
+++ b/KTHFrontpage.sty
@@ -431,7 +431,7 @@
            \raggedleft\fontsize{14}{18}\selectfont{}%
            \if@eng%
              \if@exjobb%
-               Master's Degree Project\\
+               Master of Science Thesis\\
                Stockholm, Sweden \@idate
              \fi
              \if@lic


### PR DESCRIPTION
Changed to 'Master of Science Thesis' on the English frontpage to match the the other pages and the official template.
